### PR TITLE
Fixing additional issues with non http links while crawling

### DIFF
--- a/lib/crawler/crawler.py
+++ b/lib/crawler/crawler.py
@@ -42,12 +42,12 @@ class crawler:
 		urls=self.getLinks(base,proxy,headers,cookie)
 		
 		for url in urls:
-			
-			p=Process(target=core.main, args=(url,proxy,headers,level,cookie,method))
-			p.start()
-			p.join()
-			if depth != 0:
-				self.crawl(url,depth-1,base,proxy,level,method,cookie)
-				
-			else:
-				break	
+			if url.startswith("https://") or url.startswith("http://"):
+				p=Process(target=core.main, args=(url,proxy,headers,level,cookie,method))
+				p.start()
+				p.join()
+				if depth != 0:
+					self.crawl(url,depth-1,base,proxy,level,method,cookie)
+					
+				else:
+					break	


### PR DESCRIPTION
Crawler still occasionally hit situations where it would be fed a non-http link, causing a crash. Added a check to verify that the url is an http link